### PR TITLE
Allow setting interface descriptions

### DIFF
--- a/include/libusbd.h
+++ b/include/libusbd.h
@@ -119,6 +119,7 @@ int libusbd_iface_finalize(libusbd_ctx_t* pCtx, uint8_t iface_num);
 int libusbd_iface_standard_desc(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t descType, uint8_t unk, const uint8_t* pDesc, uint64_t descSz);
 int libusbd_iface_nonstandard_desc(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t descType, uint8_t unk, const uint8_t* pDesc, uint64_t descSz);
 int libusbd_iface_add_endpoint(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t type, uint8_t direction, uint32_t maxPktSize, uint8_t interval, uint64_t unk, uint64_t* pEpOut);
+int libusbd_iface_set_description(libusbd_ctx_t* pCtx, uint8_t iface_num, const char* desc);
 int libusbd_iface_set_class(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t val);
 int libusbd_iface_set_subclass(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t val);
 int libusbd_iface_set_protocol(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t val);

--- a/src/libusbd.c
+++ b/src/libusbd.c
@@ -296,6 +296,21 @@ int libusbd_iface_add_endpoint(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t t
     return libusbd_impl_iface_add_endpoint(pCtx, iface_num, type, direction, maxPktSize, interval, unk, pEpOut);
 }
 
+int libusbd_iface_set_description(libusbd_ctx_t* pCtx, uint8_t iface_num, const char * desc)
+{
+    if (!pCtx) {
+        return LIBUSBD_INVALID_ARGUMENT;
+    }
+
+    if (iface_num >= LIBUSBD_MAX_IFACES) {
+        return LIBUSBD_INVALID_ARGUMENT;
+    }
+
+    libusbd_impl_iface_set_description(pCtx, iface_num, desc);
+
+    return LIBUSBD_SUCCESS;
+}
+
 int libusbd_iface_set_class(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t val)
 {
     if (!pCtx) {

--- a/src/plat/linux/impl.c
+++ b/src/plat/linux/impl.c
@@ -1293,6 +1293,30 @@ int libusbd_impl_iface_alloc(libusbd_ctx_t* pCtx)
     return LIBUSBD_SUCCESS;
 }
 
+int libusbd_impl_iface_set_description(libusbd_ctx_t* pCtx, uint8_t iface_num, const char *desc)
+{
+    if (!pCtx || !pCtx->pLinuxCtx) {
+        return LIBUSBD_INVALID_ARGUMENT;
+    }
+
+    if (iface_num >= LIBUSBD_MAX_IFACES) {
+        return LIBUSBD_INVALID_ARGUMENT;
+    }
+
+    libusbd_linux_ctx_t* pImplCtx = pCtx->pLinuxCtx;
+    if (pCtx->aInterfaces[iface_num].finalized) {
+        return LIBUSBD_ALREADY_FINALIZED;
+    }
+
+    /*kern_return_t ret = IOUSBDeviceInterface_SetDescription(pImplCtx, iface_num, desc);
+
+    if (ret) {
+        return LIBUSBD_NONDESCRIPT_ERROR;
+    }*/
+
+    return LIBUSBD_SUCCESS;
+}
+
 int libusbd_impl_iface_set_class(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t val)
 {
     if (!pCtx || !pCtx->pLinuxCtx) {

--- a/src/plat/linux/impl.h
+++ b/src/plat/linux/impl.h
@@ -16,6 +16,7 @@ int libusbd_impl_iface_finalize(libusbd_ctx_t* pCtx, uint8_t iface_num);
 int libusbd_impl_iface_standard_desc(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t descType, uint8_t unk, const uint8_t* pDesc, uint64_t descSz);
 int libusbd_impl_iface_nonstandard_desc(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t descType, uint8_t unk, const uint8_t* pDesc, uint64_t descSz);
 int libusbd_impl_iface_add_endpoint(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t type, uint8_t direction, uint32_t maxPktSize, uint8_t interval, uint64_t unk, uint64_t* pEpOut);
+int libusbd_impl_iface_set_description(libusbd_ctx_t* pCtx, uint8_t iface_num, const char * desc);
 int libusbd_impl_iface_set_class(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t val);
 int libusbd_impl_iface_set_subclass(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t val);
 int libusbd_impl_iface_set_protocol(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t val);

--- a/src/plat/macos/impl.h
+++ b/src/plat/macos/impl.h
@@ -16,6 +16,7 @@ int libusbd_impl_iface_finalize(libusbd_ctx_t* pCtx, uint8_t iface_num);
 int libusbd_impl_iface_standard_desc(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t descType, uint8_t unk, const uint8_t* pDesc, uint64_t descSz);
 int libusbd_impl_iface_nonstandard_desc(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t descType, uint8_t unk, const uint8_t* pDesc, uint64_t descSz);
 int libusbd_impl_iface_add_endpoint(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t type, uint8_t direction, uint32_t maxPktSize, uint8_t interval, uint64_t unk, uint64_t* pEpOut);
+int libusbd_impl_iface_set_description(libusbd_ctx_t* pCtx, uint8_t iface_num, const char * desc);
 int libusbd_impl_iface_set_class(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t val);
 int libusbd_impl_iface_set_subclass(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t val);
 int libusbd_impl_iface_set_protocol(libusbd_ctx_t* pCtx, uint8_t iface_num, uint8_t val);


### PR DESCRIPTION
This implements setting the description value of interface descriptors (under macOS only, for now)